### PR TITLE
Fix buildscript repos

### DIFF
--- a/reddinator/build.gradle
+++ b/reddinator/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'


### PR DESCRIPTION
`com.android.tools.build:gradle:2.2.2` is not available in mavenCentral, but only in jcenter.